### PR TITLE
correctly extract groups from cas attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- groups were processed as plain string and not as array how redmine expects it
 
 ## [v1.4.5] - 2021-09-08
 ### Fixed

--- a/src/app/models/auth_source_cas.rb
+++ b/src/app/models/auth_source_cas.rb
@@ -166,7 +166,7 @@ class AuthSourceCas < AuthSource
           user_mail = userAttributes["mail"]
           user_surname = userAttributes["surname"]
           user_givenName = userAttributes["givenName"]
-          user_groups = userAttributes["allgroups"].split(',') unless userAttributes["allgroups"].nil?
+          user_groups = userAttributes["allgroups"] unless userAttributes["allgroups"].nil?
 
           create_or_update_user(login, user_givenName, user_surname, user_mail, user_groups, self.id)
 


### PR DESCRIPTION
Previously it was tried to split the groups array which lead to a group name containing the string representation of the groups array.